### PR TITLE
Removing existing installations in script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,4 +5,5 @@ BASE_DIR=$(pwd)
 
 # Install dependencies for RNS deployment
 cd "$RNS_DIR"
+rm -rf node_modules package-lock.json
 npm i


### PR DESCRIPTION
Adding a step to remove the **node_modules** folder and **package-lock.json** files before installing. If we dont do this the installation fails if first was executed with a different Node version.